### PR TITLE
added _IPP_PRIVATE_STRUCTURES define which make it possible to compile

### DIFF
--- a/net-print/cnijfilter-drivers/files/cnijfilter-3.70-ppd.patch
+++ b/net-print/cnijfilter-drivers/files/cnijfilter-3.70-ppd.patch
@@ -1,11 +1,10 @@
-diff -urN cnijfilter-source-3.70-1.old/cngpijmon/src/bjcupsmon_cups.c cnijfilter-source-3.70-1/cngpijmon/src/bjcupsmon_cups.c
---- cnijfilter-source-3.70-1.old/cngpijmon/src/bjcupsmon_cups.c	2012-12-21 17:27:54.599964570 +0100
-+++ cnijfilter-source-3.70-1/cngpijmon/src/bjcupsmon_cups.c	2012-12-21 17:28:42.076966493 +0100
-@@ -20,6 +20,7 @@
+--- cnijfilter-source-3.70-1.old/cngpijmon/src/bjcupsmon_cups.c	2013-08-19 20:05:51.000000000 +0300
++++ cnijfilter-source-3.70-1/cngpijmon/src/bjcupsmon_cups.c	2013-08-19 20:06:41.000000000 +0300
+@@ -18,6 +18,7 @@
+  */
+ 
  /*** Includes ***/
++#define _IPP_PRIVATE_STRUCTURES 1
  #include <cups/cups.h>
+ #include <cups/ppd.h>
  #include <cups/language.h>
-+#include <cups/ppd.h>
- #include <sys/types.h>
- #include <unistd.h>
- #include <pwd.h>


### PR DESCRIPTION
your  version of `net-print/cnijfilter-drivers/files/cnijfilter-3.70-ppd.patch` didn't work with new `cups-1.6.3-r2` as some structures are now `hidden`. Please, apply that fixed patch and release update.
